### PR TITLE
Fixes to gears.pp example

### DIFF
--- a/examples/gears.pp
+++ b/examples/gears.pp
@@ -12,13 +12,14 @@ program gears;
 {$mode objfpc}
 
 uses
+  {$ifdef UNIX} CThreads, {$endif}
   StrUtils,
   GL,
   GLPT;
 
 (**
 
-  Draw a gear wheel.  You'll probably wglpt to call this function when
+  Draw a gear wheel.  You'll probably want to call this function when
   building a display list since we do a lot of trig here.
 
   Input:  inner_radius - radius of hole at center

--- a/examples/gears.pp
+++ b/examples/gears.pp
@@ -193,7 +193,7 @@ var
       GLPT_SetWindowShouldClose(win, True);
   end;
 
-  procedure error_callback(const error: integer; const description: string);
+  procedure error_callback(error: integer; description: string);
   begin
     writeln(stderr, description);
   end;


### PR DESCRIPTION
1. `error_callback` needs a fix to compile, otherwise I get this:
 
```
$ fpc gears.pp -Fu../
Free Pascal Compiler version 3.2.2-rrelease_3_2_2-0-g0d122c4953 [2022/05/16] for x86_64
Copyright (c) 1993-2021 by Florian Klaempfl and others
Target OS: Darwin for x86_64
Compiling gears.pp
....
gears.pp(291,40) Error: Incompatible type for arg no. 1: Got "<address of procedure(const LongInt;const ShortString);Register>", expected "<procedure variable type of procedure(LongInt;ShortString);Register>"
gears.pp(316) Fatal: There were 1 errors compiling module, stopping
Fatal: Compilation aborted
```

2. In this fork, I see one has to use CThreads on Unix.

3. And a tiny typo fix - weird word `wglpt` in the comment, should be just `want` looking at gears original C code ( https://github.com/freedesktop/mesa-demos/blob/master/src/demos/gears.c ) :)